### PR TITLE
add core.async dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.48"]
-                 [secretary "1.2.3"]])
+                 [secretary "1.2.3"]
+                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]])


### PR DESCRIPTION
accountant misses core.async dependency, uberjar fails to compile.
added [org.clojure/core.async "0.1.346.0-17112a-alpha"].