### PR TITLE
add dispatch-current! for direct links handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ You can also use Accountant to set the current path in the browser, e.g.
 (accountant/navigate! "/foo/bar/baz")
 ```
 
+If you want to dispatch the current path, just add the following:
+
+```clojure
+(dispatch-current!)
+```
+
 ## License
 
 Copyright © 2015 W. David Jarvis

--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -81,3 +81,9 @@
        (if (= old-route route)
          (. history (replaceToken with-params))
          (. history (setToken with-params))))))
+
+(defn dispatch-current! []
+  "Dispatch current URI path."
+  (let [path (-> js/window .-location .-pathname)
+        query (-> js/window .-location .-search)]
+    (secretary/dispatch! (str path query))))


### PR DESCRIPTION
Hi. I noticed a common pattern in my sites using secretary and dispatching direct links.
I call secretary.core.dispatch! function with current URI path once page is loaded.
For example I open page localhost/users/edvorg and dispatching for /users/edvorg happens immediately. That's why I suggest adding a function dispatch-current! to avoid boilerplate in application and move it to library. It just must be called once page loaded to setup page state.
I first tried to add this PR to secretary but author wants not to depend on js/window