### PR TITLE
Secretary 2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject venantius/accountant "0.1.1"
+(defproject venantius/accountant "0.2-SNAPSHOT"
   :description "Navigation for Single-Page Applications Made Easy."
   :url "http://github.com/venantius/accountant"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.48"]
-                 [secretary "1.2.3"]])
+                 [secretary "2.0.0.1-260a59"]])

--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -27,40 +27,66 @@
   to see if any of its parents are links. If so, return the href and the target content."
   [e]
   ((fn [el]
-     (if-let [href (.-href el)
-              target (.-target el)]
-        [href target]
-        (when-let [parent (.-parentNode el)]
-           (recur parent)))) (.-target e)))
+     (if-let [href (.-href el)]
+       (if-let [target (.-target el)]
+          [href target]
+          (when-let [parent (.-parentNode el)]
+             (recur parent)))
+       (when-let [parent (.-parentNode el)]
+             (recur parent)))) (.-target e)))
+
+(defn- locate-route [routes needle]
+  (some
+   (fn [route]
+     (when (secretary/route-matches route needle)
+       route))
+   routes))
 
 (defn- prevent-reload-on-known-path
   "Create a click handler that blocks page reloads for known routes in
   Secretary."
-  [history route-locator]
+  [history routes]
   (events/listen
    js/document
    "click"
    (fn [e]
-     (let [[href target] (find-a-attrs)
+     (let [[href target] (find-a-attrs e)
            parsed-uri (.parse Uri href)
            path (.getPath parsed-uri)
            domain (.getDomain parsed-uri)
            title (.-title (.-target e))]
        (when (and (or (= domain "")                    ; the domain is empty
                       (= domain (.. js/window -location -hostname))) ; or is the same of the current domain
-                  (or (nil? target)                    ; the target of the a tag is empty
-                      (= target "")                    ;   "     "     "     "
+                  (or (empty? target)                  ; the target of the a tag is empty
                       (= target "_self"))              ; or is _self
-                  (route-locator path))                ; path is handled by secretary
+                  (locate-route routes path))          ; path is handled by secretary
          (. history (setToken path title))
          (.preventDefault e))))))
 
+; this is needed as of this
+; https://code.google.com/p/closure-library/source/detail?spec=svn88dc096badf091f380b4c2b4a6514184511de657&r=88dc096badf091f380b4c2b4a6514184511de657
+; setToken doen't replace the query string, it only attach it at the end
+; solution here: https://github.com/Sparrho/supper/blob/master/src-cljs/supper/history.cljs
+(defn- build-transformer
+  "Custom transformer is needed to replace query parameters, rather
+  than adding to them.
+  See: https://gist.github.com/pleasetrythisathome/d1d9b1d74705b6771c20"
+  []
+  (let [transformer (goog.history.Html5History.TokenTransformer.)]
+    (set! (.. transformer -retrieveToken)
+          (fn [path-prefix location]
+            (str (.-pathname location) (.-search location))))
+    (set! (.. transformer -createUrl)
+          (fn [token path-prefix location]
+            (str path-prefix token)))
+    transformer))
+
 (defn configure-navigation!
   "Create and configure HTML5 history navigation."
-  [secretary-dispatcher route-locator]
-  (let [history (Html5History.)]
+  [secretary-dispatcher routes]
+  (let [history (goog.history.Html5History. js/window (build-transformer))]
     (.setUseFragment history false)
     (.setPathPrefix history "")
     (.setEnabled history true)
     (dispatch-on-navigate history secretary-dispatcher)
-    (prevent-reload-on-known-path history route-locator)))
+    (prevent-reload-on-known-path history routes)))

--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -15,44 +15,52 @@
     out))
 
 (defn- dispatch-on-navigate
-  [history]
+  [history secretary-dispatcher]
   (let [navigation (listen history EventType/NAVIGATE)]
     (go
       (while true
         (let [token (.-token (<! navigation))]
-          (secretary/dispatch! token))))))
+          (secretary-dispatcher token))))))
 
-(defn- find-href
+(defn- find-a-attrs
   "Given a DOM element that may or may not be a link, traverse up the DOM tree
-  to see if any of its parents are links. If so, return the href content."
+  to see if any of its parents are links. If so, return the href and the target content."
   [e]
-  ((fn [e]
-     (if-let [href (.-href e)]
-        href
-        (when-let [parent (.-parentNode e)]
+  ((fn [el]
+     (if-let [href (.-href el)
+              target (.-target el)]
+        [href target]
+        (when-let [parent (.-parentNode el)]
            (recur parent)))) (.-target e)))
 
 (defn- prevent-reload-on-known-path
   "Create a click handler that blocks page reloads for known routes in
   Secretary."
-  [history]
+  [history route-locator]
   (events/listen
    js/document
    "click"
    (fn [e]
-     (let [href (find-href e)
-           path (.getPath (.parse Uri href))
+     (let [[href target] (find-a-attrs)
+           parsed-uri (.parse Uri href)
+           path (.getPath parsed-uri)
+           domain (.getDomain parsed-uri)
            title (.-title (.-target e))]
-       (when (secretary/locate-route path)
+       (when (and (or (= domain "")                    ; the domain is empty
+                      (= domain (.. js/window -location -hostname))) ; or is the same of the current domain
+                  (or (nil? target)                    ; the target of the a tag is empty
+                      (= target "")                    ;   "     "     "     "
+                      (= target "_self"))              ; or is _self
+                  (route-locator path))                ; path is handled by secretary
          (. history (setToken path title))
          (.preventDefault e))))))
 
 (defn configure-navigation!
   "Create and configure HTML5 history navigation."
-  []
+  [secretary-dispatcher route-locator]
   (let [history (Html5History.)]
     (.setUseFragment history false)
     (.setPathPrefix history "")
     (.setEnabled history true)
-    (dispatch-on-navigate history)
-    (prevent-reload-on-known-path history)))
+    (dispatch-on-navigate history secretary-dispatcher)
+    (prevent-reload-on-known-path history route-locator)))

--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -28,12 +28,9 @@
   [e]
   ((fn [el]
      (if-let [href (.-href el)]
-       (if-let [target (.-target el)]
-          [href target]
-          (when-let [parent (.-parentNode el)]
-             (recur parent)))
+       [href (.-target el)]
        (when-let [parent (.-parentNode el)]
-             (recur parent)))) (.-target e)))
+         (recur parent)))) (.-target e)))
 
 (defn- locate-route [routes needle]
   (some


### PR DESCRIPTION
Update Accountant to use Secretary 2.
As discussed [here](https://github.com/venantius/accountant/issues/2) i finally had a [response](https://github.com/gf3/secretary/issues/77#issuecomment-152267562) from the Secretary guys and i updated the library accordingly.
I have also added a build-transformer function that fix a 'bug' in the goog library: https://github.com/venantius/accountant/compare/venantius:master...bago2k4:secretary-2?expand=1#diff-df459cb347a6f7594df7019c7b1db3f9R63
Finally I have improved the check on the clicked ancor because before it was checking only the path, now i check for the domain to be empty or the same and if the target of the anchor is the same window, if not we shouldn't call `e.preventDefault()`.

I tried to maintain your coding style as much as possible, we should add some tests but now i don't have the time.