### PR TITLE
trigger dispatching by left mouse button only

### DIFF
--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -43,10 +43,11 @@
    js/document
    "click"
    (fn [e]
-     (let [href (find-href e)
+     (let [button (.-button e)
+           href (find-href e)
            path (.getPath (.parse Uri href))
            title (.-title (.-target e))]
-       (when (secretary/locate-route path)
+       (when (and (= button 0) (secretary/locate-route path))
          (. history (setToken path title))
          (.preventDefault e))))))
 


### PR DESCRIPTION
This change keeps browser flow clean in cases, when user use middle or right mouse buttons.
Dispatching occur only if left button is pressed.