### PR TITLE
Add pre-navigation function hook, allow navigation cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,19 @@ If you want to dispatch the current path, just add the following:
 (dispatch-current!)
 ```
 
+If you need to execute a function prior to the token being dispatched to secretary, add the following option:
+
+```clojure
+(accountant/configure-navigation! :on-before-navigate (fn [token] (println "Navigating to -> " token) true))
+```
+
+You can use the same function to cancel a navigation by returning a falsey value.
+
+```clojure
+(accountant/configure-navigation! :on-before-navigate (constantly false))
+;; navigation events will all be ignored
+```
+
 ## License
 
 Copyright © 2015 W. David Jarvis

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject icm-consulting/accountant "0.1.6-SNAPSHOT"
+(defproject venantius/accountant "0.1.5"
   :description "Navigation for Single-Page Applications Made Easy."
   :url "http://github.com/venantius/accountant"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject venantius/accountant "0.1.5"
+(defproject icm-consulting/accountant "0.1.6-SNAPSHOT"
   :description "Navigation for Single-Page Applications Made Easy."
   :url "http://github.com/venantius/accountant"
   :license {:name "Eclipse Public License"

--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -18,12 +18,13 @@
     out))
 
 (defn- dispatch-on-navigate
-  [history]
+  [history on-before-navigate]
   (let [navigation (listen history EventType/NAVIGATE)]
     (go
       (while true
         (let [token (.-token (<! navigation))]
-          (secretary/dispatch! token))))))
+          (when (on-before-navigate token)
+            (secretary/dispatch! token)))))))
 
 (defn- find-href
   "Given a DOM element that may or may not be a link, traverse up the DOM tree
@@ -58,11 +59,11 @@
 
 (defn configure-navigation!
   "Create and configure HTML5 history navigation."
-  []
+  [& {:keys [on-before-navigate] :or {on-before-navigate (constantly true)}}]
   (.setUseFragment history false)
   (.setPathPrefix history "")
   (.setEnabled history true)
-  (dispatch-on-navigate history)
+  (dispatch-on-navigate history on-before-navigate)
   (prevent-reload-on-known-path history))
 
 (defn map->params [query]


### PR DESCRIPTION
I had the need the be able to do 2 things prior to the secretary dispatch during a History navigation event:

1. Exec a function - in particular I needed to update some state
2. Allow for cancellation of the navigation event, if required

I added an option to the ```configure-navigation!``` function: ```on-before-navigation```, a function which takes the token being navigated to, and returns a boolean/truthy value which determines whether or not the navigation should proceed - falsey if the navigation should be cancelled.
(To be honest, while I thought cancellation of navigation could be useful, I haven't had an immediate use for this in real-world code as yet).

If you're not happy with the style of option passing, that can be easily changed - I know the use of var-arg maps can be controversial.

BTW, nice project - very handy!