### PR TITLE
Correctly handle query params

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject venantius/accountant "0.1.5"
+(defproject venantius/accountant "0.1.6"
   :description "Navigation for Single-Page Applications Made Easy."
   :url "http://github.com/venantius/accountant"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
Addresses #14.

- Includes query params (and fragment) if present in the clicked link's `href`
- Does not persist query params that are not present in the clicked link's `href` (which is a "feature" introduced by Google into `goog.history.Html5History`)