### PR TITLE
dispatch the URL fragment (hash) initially as well

### DIFF
--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -121,5 +121,6 @@
 (defn dispatch-current! []
   "Dispatch current URI path."
   (let [path (-> js/window .-location .-pathname)
-        query (-> js/window .-location .-search)]
-    (secretary/dispatch! (str path query))))
+        query (-> js/window .-location .-search)
+        hash (-> js/window .-location .-hash)]
+    (secretary/dispatch! (str path query hash))))


### PR DESCRIPTION
In order to support initial dispatching of URLs, containing an URL-fragment, the "hash" property of the window.location must be handled.