### PR TITLE
reload if the target has a different hostname

### DIFF
--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -81,8 +81,10 @@
            query (uri->query uri)
            fragment (uri->fragment uri)
            relative-href (str path query fragment)
-           title (.-title target)]
-       (when (and (not any-key) (= button 0) (secretary/locate-route path))
+           title (.-title target)
+           host (.getDomain uri)
+           current-host js/window.location.hostname]
+       (when (and (not any-key) (= button 0) (secretary/locate-route path) (= host current-host))
          (set-token! history relative-href title)
          (.preventDefault e))))))
 


### PR DESCRIPTION
rn:

- if my app is mounted at `localhost`
- and I have a secretary route `/blog`
- and I click a link to `http://google.com/blog`

accountant thinks it's ok to capture that click event and route to `localhost/blog`.

