### PR TITLE
Avoid history duplicates by not adding history entries if the …

### DIFF
--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -81,8 +81,14 @@
            relative-href (str path query fragment)
            title (.-title target)
            host (.getDomain uri)
-           current-host js/window.location.hostname]
-       (when (and (not any-key) (= button 0) (path-exists? path) (= host current-host))
+           current-host js/window.location.hostname
+           loc js/window.location
+           current-relative-href (str (.-pathname loc) (.-query loc) (.-hash loc))]
+       (when (and (not any-key)
+                  (= button 0)
+                  (= host current-host)
+                  (not= current-relative-href relative-href)
+                  (path-exists? path))
          (set-token! history relative-href title)
          (.preventDefault e))))))
 


### PR DESCRIPTION
…relative href is equal to the currently active one. This is useful in scenarios where a page contains links with empty hrefs (browser then assumes the current location as href). Currently, accountant will insert the same history entry for each click on one of these links, leading to duplicates in the history.