### PR TITLE
preserve hash and query string on back events

### DIFF
--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -27,7 +27,7 @@
   (str (.-pathname location) (.-search location) (.-hash location)))
 
 (defonce history
-  (let [transformer goog.history.Html5History.TokenTransformer.]
+  (let [transformer (goog.history.Html5History.TokenTransformer.)]
     (set! (.. transformer -retrieveToken) transformer-retrieve-token)
     (set! (.. transformer -createUrl) transformer-create-url)
     (Html5History. js/window transformer)))


### PR DESCRIPTION
This PR fixes #19 and #23, and incorporates the patches in PR #24.

It appears that there were some outstanding issues with that PR, and it appears to have been abandoned. This one incorporates that patch and resolves the issues that @venantius mentioned.

Duplicate of #29, which I botched.