### PR TITLE
Allow users to tag links as 'non-navigational'

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ If you want to dispatch the current path, just add the following:
 
 Note that both `navigate!` and `dispatch-current!` can only be used after calling `configure-navigation!`
 
+Sometimes you may want to use `<a>` elements not as links to other pages but rather as a button, to trigger some action. In these cases, even if a `href` attribute is missing, browsers may use the domain name of the current location as the `href` value. If you want accountant to ignore these non-linking links, add a `data-no-nav` attribute to it like this:
+
+```html
+<a href="" data-no-nav="true" on-click="..." ...>
+```
 ## License
 
 Copyright © 2015 W. David Jarvis

--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -27,12 +27,15 @@
 
 (defn- find-href
   "Given a DOM element that may or may not be a link, traverse up the DOM tree
-  to see if any of its parents are links. If so, return the href content."
+  to see if any of its parents are links. If so, return the href content, if it 
+does not have a trueish 'data-no-nav'."
   [e]
-  (if-let [href (.-href e)]
-    href
-    (when-let [parent (.-parentNode e)]
-      (recur parent))))
+  (let [href (.-href e)]
+    (if (and href
+             (not (.getAttribute e "data-no-nav")))
+      href
+      (when-let [parent (.-parentNode e)]
+        (recur parent)))))
 
 (defn- get-url
   "Gets the URL for a history token, but without preserving the query string


### PR DESCRIPTION
This is especially useful in react components that use <a> links internally to trigger callback code rather than as a real link. In these instances we don't want to add duplicated history entries.