### PR TITLE
feat: port number in check

### DIFF
--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -81,12 +81,15 @@
            relative-href (str path query fragment)
            title (.-title target)
            host (.getDomain uri)
+           port (.getPort uri)
            current-host js/window.location.hostname
+           current-port js/window.location.port
            loc js/window.location
            current-relative-href (str (.-pathname loc) (.-query loc) (.-hash loc))]
        (when (and (not any-key)
                   (= button 0)
                   (= host current-host)
+                  (= port current-port)
                   (not= current-relative-href relative-href)
                   (path-exists? path))
          (set-token! history relative-href title)


### PR DESCRIPTION
The existing implementation only checks based on the hostname. If a uri links to
a different portnumber on the same host, this was not considered a redirect. In
situations like local development were multiple services might be running on the
same host, this results in links not working.

This commit includes the portnumber into the validation. In case no explicit
port is mentioned, both `port` and `current-port` will return nil. If an
explicit port is used, the comparison will be based on port numbers.

I have not verified the browser support of this feature, so I do not know if
this breaks any existing setups on non-mainstream browsers.