### PR TITLE
Ensure uri.getPort is converted from number to string [#36]

### DIFF
--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -83,7 +83,7 @@
            relative-href (str path query fragment)
            title (.-title target)
            host (.getDomain uri)
-           port (.getPort uri)
+           port (str (.getPort uri))
            current-host js/window.location.hostname
            current-port js/window.location.port
            loc js/window.location


### PR DESCRIPTION
* `window.location.port` returns a string, defaults to `""`
* `uri.getPort` returns a number, defaults to `nil`

Wrapping `uri.getPort` in `str` ensures they are both the same format, allowing equivalence check to pass when required.