### PR TITLE
Ignore links with `data-trigger` attribute: links that are actions

### DIFF
--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -25,14 +25,20 @@
         (let [token (.-token (<! navigation))]
           (nav-handler token))))))
 
+
 (defn- find-href-node
   "Given a DOM element that may or may not be a link, traverse up the DOM tree
-  to see if any of its parents are links. If so, return the node."
+  to see if any of its parents are links. If so, return the href content, if 
+  it does not have an explicit `data-trigger` attribute to signify a non-navigational
+  link element."
   [e]
-  (if (.-href e)
-    e
-    (when-let [parent (.-parentNode e)]
-      (recur parent))))
+  (let [href (.-href e)
+        attrs (.-attributes e)
+        navigation-link? (and href attrs (-> attrs (aget "data-trigger") not))]
+    (if navigation-link?
+      e
+      (when-let [parent (.-parentNode e)]
+        (recur parent)))))
 
 (defn- get-url
   "Gets the URL for a history token, but without preserving the query string


### PR DESCRIPTION
Sometimes, especially when using third-party widgets like the [MenuItems](https://react-bootstrap.github.io/components.html#menu-items) in [react-bootstrap](https://react-bootstrap.github.io) links should not navigate to another page but should behave like buttons. Currently, accountant will either navigate itself (if "#" is a registered route) or the browser itself will load the root url+# fragement.

To allow the user to explicitely mark a link as being a "button" I suggest we support an explicit `data-trigger` attribute for links. If present, accountant ignores the link completely. This PR might also be useful for issue https://github.com/venantius/accountant/issues/27