### PR TITLE
Fix #19 by calling set-token in navigate!

### DIFF
--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -141,7 +141,7 @@
                          (str route "?" query-string))]
        (if (= old-route route)
          (. history (replaceToken with-params))
-         (. history (setToken with-params))))
+         (set-token! history with-params nil)))
      (js/console.error "can't navigate! until configure-navigation! called"))))
 
 (defn dispatch-current! []


### PR DESCRIPTION
When calling navigate! directly query params are persisted,
this appears to be due to googles setToken method incorrectly
doing so. There is already an implementation of set-token
that works correctly, so have navigate call that instead.