### PR TITLE
Fix page reload blocking for image links on IE11 #49

### DIFF
--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -29,6 +29,12 @@
       (let [token (.-token e)]
         (nav-handler token)))))
 
+(defn- get-href-attribute
+  "Given a DOM node, if it is an element node, return its href attribute.
+  Otherwise, return nil."
+  [node]
+  (when (and node (= (.-nodeType node) js/Node.ELEMENT_NODE))
+    (.getAttribute node "href")))
 
 (defn- find-href-node
   "Given a DOM element that may or may not be a link, traverse up the DOM tree
@@ -36,7 +42,7 @@
   it does not have an explicit `data-trigger` attribute to signify a non-navigational
   link element."
   [e]
-  (let [href (.-href e)
+  (let [href (get-href-attribute e)
         attrs (.-attributes e)
         navigation-link? (and href attrs (-> attrs (aget "data-trigger") not))]
     (if navigation-link?


### PR DESCRIPTION
I tested the change on these browsers and didn't run into any issues:

- IE11
- Firefox 56.0.2
- Safari 11
- Chrome 61
- Opera 48