### PR TITLE
Add unconfigure-navigation! function

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ If you want to dispatch the current path, just add the following:
 
 Note that both `navigate!` and `dispatch-current!` can only be used after calling `configure-navigation!`
 
+To cleanup the resources allocated by `configure-navigation!`, use `unconfigure-navigation!`. This is useful
+in cases where you create a component that manages configuring navigation, and would like to be able to easily
+start/stop it.
+
+```clojure
+(accountant/unconfigure-navigation!)
+```
+
 ### Caveat: UI Frameworks
 Sometimes links may be used nested within UI components, especially when using third-party wrappers, like [react-bootstrap](https://react-bootstrap.github.io/) etc. These links may have an empty `href` attribute or a value like `#`. Two things might happen: Either, if a route is defined for the root path (i.e. '/' or '/#'), accountant will suppress the browser navigation and dispatch via secretary or the browser will reload the page.
 

--- a/src/accountant/core.cljs
+++ b/src/accountant/core.cljs
@@ -104,6 +104,8 @@
 
 (defonce nav-handler nil)
 (defonce path-exists? nil)
+(defonce document-click-handler-listener-key nil)
+(defonce navigate-listener-key nil)
 
 (defn configure-navigation!
   "Create and configure HTML5 history navigation.
@@ -119,8 +121,19 @@
   (.setEnabled history true)
   (set! accountant.core/nav-handler nav-handler)
   (set! accountant.core/path-exists? path-exists?)
-  (dispatch-on-navigate history nav-handler)
-  (prevent-reload-on-known-path history path-exists? reload-same-path?))
+  (set! document-click-handler-listener-key (dispatch-on-navigate history nav-handler))
+  (set! navigate-listener-key (prevent-reload-on-known-path history path-exists? reload-same-path?)))
+
+(defn unconfigure-navigation!
+  "Teardown HTML5 history navigation.
+
+  Undoes all of the stateful changes, including unlistening to events, that are setup as part of
+  the call to `configure-navigation!`."
+  []
+  (set! nav-handler nil)
+  (set! path-exists? nil)
+  (doseq [key [document-click-handler-listener-key navigate-listener-key]]
+    (when key (events/unlistenByKey key))))
 
 (defn map->params [query]
   (let [params (map #(name %) (keys query))


### PR DESCRIPTION
Attempts to address the feature request from https://github.com/venantius/accountant/issues/57.

After digging into the code, I realized that there are two event listeners that are created as part of `configure-navigation!`, and I capture the listener keys for them. `unconfigure-navigation!` uses these keys to allow `unlistenByKey` to clean them up.