### PR TITLE
Add deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,4 @@
+{:deps
+ {org.clojure/clojure {:mvn/version "1.7.0"},
+  org.clojure/clojurescript {:mvn/version "1.7.48"}}}
+


### PR DESCRIPTION
I'm needing the `unconfigure-navigation!` feature from bc9cffa323792c1062197b0eebd67f499940551f and using a git SHA reference from my `deps.edn` is the easiest way to get it.  But this repo needs to have a `deps.edn` in order to work.  `project.clj` could optionally be updated to use `deps.edn` with a plugin.