### PR TITLE
Add the option to dispatch the handler with the URL components as a map instead of a raw string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ navigation handler by setting `reload-same-path?` to true during configuration.
                                    :reload-same-path? true})
 ```
 
+By default, a string of the raw URL (`/path?foo=bar#p1`) is passed to the handler. You can
+alternatively pass this as a map, so you don't have to parse it yourself if it fits your needs:
+```clojure
+(accountant/configure-navigation! {...
+                                   :pass-map-to-handler? true}
+```
+
 You can also use Accountant to set the current path in the browser, e.g.
 
 ```clojure

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ By default, a string of the raw URL (`/path?foo=bar#p1`) is passed to the handle
 alternatively pass this as a map, so you don't have to parse it yourself if it fits your needs:
 ```clojure
 (accountant/configure-navigation! {...
-                                   :pass-map-to-handler? true}
+                                   :pass-map-to-handler? true})
+
+=> {:path "/path" :query "?foo=bar" :hash "#p1"}
 ```
 
 You can also use Accountant to set the current path in the browser, e.g.


### PR DESCRIPTION
Quite likely, you might want to parse the URL in your routing handler anyway. Since Accountant concatenates the components back into a single string by default, you should be able to disable it if you want to.